### PR TITLE
feat: #WB2-644, enable apps to crud folders in explore

### DIFF
--- a/deployment/blog/conf.j2
+++ b/deployment/blog/conf.j2
@@ -14,6 +14,8 @@
         "host": "https://{{ host }}",
         "userbook-host": "https://{{ host }}",
         "mode": "prod",
+        "use-explorer-folder-api": {{ blogUseExplorerApi | default(true) }},
+        "use-explorer-ui": {{ blogUseExplorerUi | default(true) }},
         "publicConf": {
             "xiti": {
                 "ID_SERVICE": {

--- a/deployment/blog/conf.json.template
+++ b/deployment/blog/conf.json.template
@@ -12,6 +12,8 @@
       "host": "${host}",
       "userbook-host": "${host}",
       "mode": "${mode}",
+      "use-explorer-folder-api": true,
+      "use-explorer-ui": true,
       "publicConf": {
           <% if ("true".equals(xitiSwitch)) { %>
             "xiti": {

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,6 +28,6 @@ junitVersion=4.10
 
 # compile lib
 entCoreVersion=4.10-explorer-SNAPSHOT
-explorerVersion=1.1-SNAPSHOT
+explorerVersion=1.2-SNAPSHOT
 
 runModsArgs=

--- a/src/main/java/org/entcore/blog/Blog.java
+++ b/src/main/java/org/entcore/blog/Blog.java
@@ -24,9 +24,7 @@
 package org.entcore.blog;
 
 import fr.wseduc.mongodb.MongoDb;
-import org.entcore.blog.controllers.BlogController;
-import org.entcore.blog.controllers.FoldersController;
-import org.entcore.blog.controllers.PostController;
+import org.entcore.blog.controllers.*;
 import org.entcore.blog.events.BlogSearchingEvents;
 import org.entcore.blog.explorer.BlogExplorerPlugin;
 import org.entcore.blog.explorer.PostExplorerPlugin;
@@ -76,7 +74,11 @@ public class Blog extends BaseServer {
                 config.getInteger("blog-search-word-min-size", 4), blogPlugin);
         addController(new BlogController(mongo, blogService, postService));
         addController(new PostController(blogService, postService));
-        addController(new FoldersController("blogsFolders"));
+        if(config().getBoolean("use-explorer-folder-api", true)){
+            addController(new FoldersControllerProxy(new FoldersControllerExplorer(vertx, blogPlugin)));
+        }else{
+            addController(new FoldersControllerProxy(new FoldersControllerLegacy("blogsFolders")));
+        }
         blogPlugin.start();
     }
 

--- a/src/main/java/org/entcore/blog/controllers/BlogController.java
+++ b/src/main/java/org/entcore/blog/controllers/BlogController.java
@@ -106,16 +106,13 @@ public class BlogController extends BaseController {
 	@Get("")
 	@SecuredAction("blog.view")
 	public void blog(HttpServerRequest request) {
-		renderView(request);
-		eventHelper.onAccess(request);
-	}
-
-	@Get("/explorer")
-//	TODO @SecuredAction("blog.explore")
-	public void blogExplorer(HttpServerRequest request) {
-//		String language = Utils.getOrElse(I18n.acceptLanguage(request), "fr", false);
-		renderView(request, new JsonObject()/*.put("lang",I18n.getLocale(language).getLanguage())*/, "blog-explorer.html", null);
-		eventHelper.onAccess(request);
+		if(this.config.getBoolean("use-explorer-ui", true)){
+			renderView(request, new JsonObject(), "blog-explorer.html", null);
+			eventHelper.onAccess(request);
+		}else{
+			renderView(request);
+			eventHelper.onAccess(request);
+		}
 	}
 
 	@Get("/print/blog")

--- a/src/main/java/org/entcore/blog/controllers/FoldersController.java
+++ b/src/main/java/org/entcore/blog/controllers/FoldersController.java
@@ -1,58 +1,10 @@
 package org.entcore.blog.controllers;
 
-import fr.wseduc.rs.*;
-import fr.wseduc.security.ActionType;
-import fr.wseduc.security.SecuredAction;
-import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.json.JsonObject;
-import org.entcore.blog.security.FolderOwner;
-import org.entcore.common.http.filter.ResourceFilter;
-import org.entcore.common.mongodb.MongoDbControllerHelper;
-import org.vertx.java.core.http.RouteMatcher;
 
-import java.util.Map;
-
-public class FoldersController extends MongoDbControllerHelper {
-
-	public FoldersController(String collectionName) {
-		super(collectionName);
-	}
-
-	@Override
-	public void init(Vertx vertx, JsonObject config, RouteMatcher rm,
-					 Map<String, fr.wseduc.webutils.security.SecuredAction> securedActions) {
-		super.init(vertx, config, rm, securedActions);
-	}
-
-	@Override
-	@Get("folder/list/:filter")
-	@ApiDoc("List all user folders.")
-	@SecuredAction("blog.listFolders")
-	public void list(HttpServerRequest request) {
-		super.list(request);
-	}
-
-	@Post("folder")
-	@ApiDoc("Add folder.")
-	@SecuredAction("blog.createFolder")
-	public void add(HttpServerRequest request) {
-		create(request);
-	}
-
-	@Override
-	@Put("folder/:id")
-	@ApiDoc("Update folder by id.")
-	@ResourceFilter(FolderOwner.class)
-	public void update(HttpServerRequest request) {
-		super.update(request);
-	}
-
-	@Override
-	@Delete("folder/:id")
-	@ApiDoc("Delete folder by id.")
-	@ResourceFilter(FolderOwner.class)
-	public void delete(HttpServerRequest request) {
-		super.delete(request);
-	}
+public interface FoldersController {
+	void list(HttpServerRequest request);
+	void add(HttpServerRequest request);
+	void update(HttpServerRequest request);
+	void delete(HttpServerRequest request);
 }

--- a/src/main/java/org/entcore/blog/controllers/FoldersControllerExplorer.java
+++ b/src/main/java/org/entcore/blog/controllers/FoldersControllerExplorer.java
@@ -1,0 +1,135 @@
+package org.entcore.blog.controllers;
+
+import fr.wseduc.webutils.http.Renders;
+import fr.wseduc.webutils.request.RequestUtils;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.entcore.blog.Blog;
+import org.entcore.blog.explorer.BlogExplorerPlugin;
+import org.entcore.common.explorer.to.FolderDeleteRequest;
+import org.entcore.common.explorer.to.FolderListRequest;
+import org.entcore.common.explorer.to.FolderResponse;
+import org.entcore.common.explorer.to.FolderUpsertRequest;
+import org.entcore.common.user.UserUtils;
+
+import java.util.Arrays;
+
+public class FoldersControllerExplorer implements FoldersController {
+	private final Vertx vertx;
+	private final BlogExplorerPlugin plugin;
+	public FoldersControllerExplorer(final Vertx vertx, final BlogExplorerPlugin plugin) {
+		this.vertx = vertx;
+		this.plugin = plugin;
+	}
+
+	private JsonObject adapt(final FolderResponse response){
+		final JsonObject owner = new JsonObject().put("userId",response.getOwnerUserId()).put("displayName", response.getOwnerUserName());
+		final JsonObject folder = new JsonObject();
+		folder.put("created", new JsonObject().put("$date", response.getCreated()));
+		folder.put("modified", new JsonObject().put("$date", response.getModified()));
+		folder.put("name", response.getName());
+		folder.put("owner", owner);
+		folder.put("ressourceIds",new JsonArray(response.getEntResourceIds()));
+		folder.put("id", response.getId());
+		folder.put("_id", response.getId().toString());
+		folder.put("trashed", response.getTrashed());
+		if(response.getParentId() != null){
+			folder.put("parentId", response.getParentId().toString());
+		}else{
+			folder.put("parentId", "root");
+		}
+		return folder;
+	}
+
+	@Override
+	public void list(HttpServerRequest request) {
+		RequestUtils.bodyToJson(request,  data-> {
+			UserUtils.getUserInfos(this.vertx.eventBus(), request, user -> {
+				if (user != null) {
+					plugin.listFolder(user, new FolderListRequest(user, Blog.APPLICATION)).onComplete(result -> {
+						if(result.succeeded()){
+							final JsonArray folders = new JsonArray();
+							for(final FolderResponse response : result.result()){
+								folders.add(this.adapt(response));
+							}
+							Renders.renderJson(request, folders);
+						}else{
+							Renders.renderError(request, new JsonObject().put("error", result.cause().getMessage()));
+						}
+					});
+				} else {
+					Renders.unauthorized(request);
+				}
+			});
+		});
+	}
+
+	@Override
+	public void add(HttpServerRequest request) {
+		RequestUtils.bodyToJson(request,  data-> {
+			UserUtils.getUserInfos(this.vertx.eventBus(), request, user -> {
+				if (user != null) {
+					final Object parentId = data.getValue("parentId");
+					final String name = data.getString("name");
+					final Long safeParentId = parentId != null ? NumberUtils.toLong(parentId.toString()) : null;
+					plugin.upsertFolder(user, new FolderUpsertRequest(user, safeParentId, Blog.APPLICATION, name)).onComplete(result -> {
+						if(result.succeeded()){
+							Renders.renderJson(request, this.adapt(result.result()));
+						}else{
+							Renders.renderError(request, new JsonObject().put("error", result.cause().getMessage()));
+						}
+					});
+				} else {
+					Renders.unauthorized(request);
+				}
+			});
+		});
+	}
+
+	@Override
+	public void update(HttpServerRequest request) {
+		RequestUtils.bodyToJson(request,  data-> {
+			UserUtils.getUserInfos(this.vertx.eventBus(), request, user -> {
+				if (user != null) {
+					final Object parentId = data.getValue("parentId");
+					final Long safeParentId = parentId != null ? NumberUtils.toLong(parentId.toString()) : null;
+					final Boolean trashed = data.getBoolean("trashed");
+					final String id = request.params().get("id");
+					final Long safeId = NumberUtils.toLong(id);
+					final String name = data.getString("name");
+					plugin.upsertFolder(user, new FolderUpsertRequest(user, safeId, safeParentId, trashed, Blog.APPLICATION, name)).onComplete(result -> {
+						if(result.succeeded()){
+							Renders.renderJson(request, this.adapt(result.result()));
+						}else{
+							Renders.renderError(request, new JsonObject().put("error", result.cause().getMessage()));
+						}
+					});
+				} else {
+					Renders.unauthorized(request);
+				}
+			});
+		});
+	}
+
+	@Override
+	public void delete(HttpServerRequest request) {
+		UserUtils.getUserInfos(this.vertx.eventBus(), request, user -> {
+			if (user != null) {
+				final String id = request.params().get("id");
+				final Long safeId = NumberUtils.toLong(id);
+				plugin.deleteFolder(user, new FolderDeleteRequest(user, Arrays.asList(safeId),Blog.APPLICATION)).onComplete(result -> {
+					if(result.succeeded()){
+						Renders.noContent(request);
+					}else{
+						Renders.renderError(request, new JsonObject().put("error", result.cause().getMessage()));
+					}
+				});
+			} else {
+				Renders.unauthorized(request);
+			}
+		});
+	}
+}

--- a/src/main/java/org/entcore/blog/controllers/FoldersControllerLegacy.java
+++ b/src/main/java/org/entcore/blog/controllers/FoldersControllerLegacy.java
@@ -1,0 +1,31 @@
+package org.entcore.blog.controllers;
+
+import io.vertx.core.http.HttpServerRequest;
+import org.entcore.common.mongodb.MongoDbControllerHelper;
+
+public class FoldersControllerLegacy extends MongoDbControllerHelper implements FoldersController {
+
+	public FoldersControllerLegacy(String collectionName) {
+		super(collectionName);
+	}
+
+	@Override
+	public void list(HttpServerRequest request) {
+		super.list(request);
+	}
+
+	@Override
+	public void add(HttpServerRequest request) {
+		create(request);
+	}
+
+	@Override
+	public void update(HttpServerRequest request) {
+		super.update(request);
+	}
+
+	@Override
+	public void delete(HttpServerRequest request) {
+		super.delete(request);
+	}
+}

--- a/src/main/java/org/entcore/blog/controllers/FoldersControllerProxy.java
+++ b/src/main/java/org/entcore/blog/controllers/FoldersControllerProxy.java
@@ -1,0 +1,61 @@
+package org.entcore.blog.controllers;
+
+import fr.wseduc.rs.*;
+import fr.wseduc.security.SecuredAction;
+import fr.wseduc.webutils.http.BaseController;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonObject;
+import org.entcore.blog.security.FolderOwner;
+import org.entcore.common.http.filter.ResourceFilter;
+import org.entcore.common.mongodb.MongoDbControllerHelper;
+import org.vertx.java.core.http.RouteMatcher;
+
+import java.util.Map;
+
+public class FoldersControllerProxy extends BaseController implements FoldersController {
+
+	private final FoldersController controller;
+
+	public FoldersControllerProxy(final FoldersController controller) {
+		this.controller = controller;
+	}
+
+	@Override
+	public void init(Vertx vertx, JsonObject config, RouteMatcher rm,
+					 Map<String, fr.wseduc.webutils.security.SecuredAction> securedActions) {
+		super.init(vertx, config, rm, securedActions);
+	}
+
+	@Override
+	@Get("folder/list/:filter")
+	@ApiDoc("List all user folders.")
+	@SecuredAction("blog.listFolders")
+	public void list(HttpServerRequest request) {
+		this.controller.list(request);
+	}
+
+	@Override
+	@Post("folder")
+	@ApiDoc("Add folder.")
+	@SecuredAction("blog.createFolder")
+	public void add(HttpServerRequest request) {
+		this.controller.add(request);
+	}
+
+	@Override
+	@Put("folder/:id")
+	@ApiDoc("Update folder by id.")
+	@ResourceFilter(FolderOwner.class)
+	public void update(HttpServerRequest request) {
+		this.controller.update(request);
+	}
+
+	@Override
+	@Delete("folder/:id")
+	@ApiDoc("Delete folder by id.")
+	@ResourceFilter(FolderOwner.class)
+	public void delete(HttpServerRequest request) {
+		this.controller.delete(request);
+	}
+}

--- a/src/test/java/org/entcore/blog/FolderControllerExplorerTest.java
+++ b/src/test/java/org/entcore/blog/FolderControllerExplorerTest.java
@@ -1,0 +1,376 @@
+package org.entcore.blog;
+
+import com.opendigitaleducation.explorer.ingest.IngestJobMetricsRecorderFactory;
+import com.opendigitaleducation.explorer.tests.ExplorerTestHelper;
+import fr.wseduc.mongodb.MongoDb;
+import fr.wseduc.webutils.http.HttpMethod;
+import fr.wseduc.webutils.security.SecuredAction;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.mongo.MongoClient;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.entcore.blog.controllers.FoldersControllerExplorer;
+import org.entcore.blog.controllers.PostController;
+import org.entcore.blog.explorer.BlogExplorerPlugin;
+import org.entcore.blog.explorer.PostExplorerPlugin;
+import org.entcore.blog.services.BlogService;
+import org.entcore.blog.services.PostService;
+import org.entcore.blog.services.impl.DefaultBlogService;
+import org.entcore.blog.services.impl.DefaultPostService;
+import org.entcore.common.explorer.IExplorerPluginCommunication;
+import org.entcore.common.mongodb.MongoDbConf;
+import org.entcore.common.user.UserInfos;
+import org.entcore.test.HttpTestHelper;
+import org.entcore.test.TestHelper;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.containers.Neo4jContainer;
+
+import java.util.*;
+
+@RunWith(VertxUnitRunner.class)
+public class FolderControllerExplorerTest {
+    static final String RIGHT = "org-entcore-blog-controllers-BlogController|get";
+    private static final TestHelper test = TestHelper.helper();
+    @ClassRule
+    public static Neo4jContainer<?> neo4jContainer = test.database().createNeo4jContainer();
+    @ClassRule
+    public static ExplorerTestHelper explorerTest = new ExplorerTestHelper(BlogExplorerPlugin.APPLICATION);
+    @ClassRule
+    public static MongoDBContainer mongoDBContainer = test.database().createMongoContainer().withReuse(true);
+    static BlogExplorerPlugin blogPlugin;
+    static BlogService blogService;
+    static FoldersControllerExplorer controllerExplorer;
+    static final String application = BlogExplorerPlugin.APPLICATION;
+    static final String resourceType = BlogExplorerPlugin.TYPE;
+    static Map<String, Object> data = new HashMap<>();
+    static final UserInfos user = test.directory().generateUser("user-foldercontroller0");
+    static final UserInfos user1 = test.directory().generateUser("user-foldercontroller1");
+    static final UserInfos user2 = test.directory().generateUser("user-foldercontroller2");
+    static final UserInfos user3 = test.directory().generateUser("user-foldercontroller3");
+    static final UserInfos user4 = test.directory().generateUser("user-foldercontroller4");
+
+    @BeforeClass
+    public static void setUp(TestContext context) throws Exception {
+        IngestJobMetricsRecorderFactory.init(test.vertx(), new JsonObject());
+        test.database().initNeo4j(context, neo4jContainer);
+        user.setLogin("user1");
+        user2.setLogin("user2");
+        explorerTest.start(context);
+        test.database().initMongo(context, mongoDBContainer);
+        MongoDbConf.getInstance().setCollection("blogs");
+        MongoDb mongo = MongoDb.getInstance();
+        final int POST_SEARCH_WORD = 4;
+        final int BLOG_PAGING = 30;
+        final int BLOG_SEARCH_WORD = 4;
+        final Map<String, SecuredAction> securedActions = test.share().getSecuredActions(context);
+        final IExplorerPluginCommunication communication = explorerTest.getCommunication();
+        final MongoClient mongoClient = test.database().createMongoClient(mongoDBContainer);
+        blogPlugin = new BlogExplorerPlugin(communication, mongoClient, securedActions);
+        final PostExplorerPlugin postPlugin = blogPlugin.postPlugin();
+        final PostService postService = new DefaultPostService(mongo, POST_SEARCH_WORD, PostController.LIST_ACTION, postPlugin);
+        controllerExplorer = new FoldersControllerExplorer(test.vertx(), blogPlugin);
+        blogService = new DefaultBlogService(mongo, postService, BLOG_PAGING, BLOG_SEARCH_WORD, blogPlugin);
+    }
+
+
+    static JsonObject createBlog(final String name) {
+        return new JsonObject().put("title", name).put("description", "description" + name).put("slug", "slug" + name).put("thumbnail", "thumb" + name).put("comment-type", "IMMEDIATE");
+    }
+
+    static JsonObject createFolder(final String name, final Boolean trashed, final Long parentId) {
+        return new JsonObject().put("name", name).put("trashed", trashed).put("parentId", parentId);
+    }
+
+    static JsonObject createFolder(final String name) {
+        return new JsonObject().put("name", name);
+    }
+
+    /**
+     * <u>GOAL</u> : Ensure that we are able to create a folder tree
+     *
+     * <u>STEPS</u> :
+     * <ol>
+     *     <li>Create folder1 for user </li>
+     *     <li>Create folder2 for user (child of folder1) </li>
+     *     <li>List all folders => Should have 2 folders with folder2 child of folder1 </li>
+     * </ol>
+     * @param context
+     * @throws Exception
+     */
+    @Test
+    public void shouldCreateFolderTree(TestContext context) throws Exception {
+        final Async async = context.async();
+        final HttpTestHelper.TestHttpServerRequest reqList1 = test.http().request(HttpMethod.GET, "/folders/list/all", new JsonObject());
+        reqList1.response().endJsonArrayHandler(resultList1 -> {
+            context.assertEquals(0, resultList1.size());
+            // create folder 1
+            try {
+                final HttpTestHelper.TestHttpServerRequest reqCreate1 = test.http().request(HttpMethod.POST, "/folders", new JsonObject(), createFolder("folder1"));
+                reqCreate1.response().endJsonHandler(resultCreate1 -> {
+                    context.assertNotNull(resultCreate1, "Created folder1 should not be null");
+                    context.assertNotNull(resultCreate1.getValue("_id"), "Created folder1 should have an id");
+                    final Long parentId1 = NumberUtils.toLong(resultCreate1.getValue("_id").toString());
+                    explorerTest.ingestJobExecute(true).onComplete(context.asyncAssertSuccess(r4 -> {
+                        // create sub folder 2
+                        try {
+                            final HttpTestHelper.TestHttpServerRequest reqCreate2 = test.http().request(HttpMethod.POST, "/folders", new JsonObject(), createFolder("folder2", false, parentId1));
+                            reqCreate2.response().endJsonHandler(resultCreate2 -> {
+                                explorerTest.ingestJobExecute(true).onComplete(context.asyncAssertSuccess(r5 -> {
+                                    try {
+                                        context.assertNotNull(resultCreate2, "Created folder2 should not be null");
+                                        context.assertNotNull(resultCreate2.getValue("_id"), "Created folder2 should have an id");
+                                        context.assertNotNull(resultCreate2.getValue("parentId"), "Created folder2 should have a parent");
+                                        final HttpTestHelper.TestHttpServerRequest reqList2 = test.http().request(HttpMethod.GET, "/folders/list/all", new JsonObject());
+                                        reqList2.response().endJsonArrayHandler(resultList2 -> {
+                                            context.assertEquals(2, resultList2.size());
+                                            final JsonObject folder1 = resultList2.getJsonObject(0);
+                                            final JsonObject folder2 = resultList2.getJsonObject(1);
+                                            context.assertNotNull(folder1.getValue("_id"));
+                                            context.assertEquals("folder1", folder1.getString("name"));
+                                            context.assertEquals("root", folder1.getValue("parentId").toString());
+                                            context.assertFalse(folder1.getBoolean("trashed"));
+                                            context.assertNotNull(folder1.getValue("created"));
+                                            context.assertNotNull(folder1.getValue("modified"));
+                                            context.assertEquals(0, folder1.getJsonArray("ressourceIds").size());
+                                            context.assertNotNull(folder2.getValue("_id"));
+                                            context.assertEquals("folder2", folder2.getString("name"));
+                                            context.assertEquals(folder1.getValue("_id").toString(), folder2.getValue("parentId").toString());
+                                            context.assertFalse(folder2.getBoolean("trashed"));
+                                            context.assertNotNull(folder2.getValue("created"));
+                                            context.assertNotNull(folder2.getValue("modified"));
+                                            context.assertEquals(0, folder2.getJsonArray("ressourceIds").size());
+                                            async.complete();
+                                        });
+                                        controllerExplorer.list(reqList2.withSession(user));
+                                    } catch (Exception e) {
+                                        context.fail(e);
+                                    }
+                                }));
+                            });
+                            controllerExplorer.add(reqCreate2.withSession(user));
+                        } catch (Exception e) {
+                            context.fail(e);
+                        }
+                    }));
+                });
+                controllerExplorer.add(reqCreate1.withSession(user));
+            } catch (Exception e) {
+                context.fail(e);
+            }
+        });
+        controllerExplorer.list(reqList1.withSession(user));
+    }
+    /**
+     * <u>GOAL</u> : Ensure that we are able to create a folder tree
+     *
+     * <u>STEPS</u> :
+     * <ol>
+     *     <li>Create folder1 for user1 </li>
+     *     <li>Update folder1 for user1 => renamed to "renamed" </li>
+     *     <li>List all folders => Should have 1 folder renamed </li>
+     *     <li>Delete folder1 for user1</li>
+     *     <li>List all folders => Should have O folders </li>
+     * </ol>
+     * @param context
+     * @throws Exception
+     */
+    @Test
+    public void shouldCrudFolder(TestContext context) throws Exception {
+        final Async async = context.async();
+        final HttpTestHelper.TestHttpServerRequest reqList1 = test.http().request(HttpMethod.GET, "/folders/list/all", new JsonObject());
+        reqList1.response().endJsonArrayHandler(resultList1 -> {
+            context.assertEquals(0, resultList1.size());
+            // create folder 1
+            try {
+                final HttpTestHelper.TestHttpServerRequest reqCreate1 = test.http().request(HttpMethod.POST, "/folders", new JsonObject(), createFolder("folder1"));
+                reqCreate1.response().endJsonHandler(resultCreate1 -> {
+                    context.assertNotNull(resultCreate1, "Created folder1 should not be null");
+                    context.assertNotNull(resultCreate1.getValue("_id"), "Created folder1 should have an id");
+                    final Long folderId = NumberUtils.toLong(resultCreate1.getValue("_id").toString());
+                    explorerTest.ingestJobExecute(true).onComplete(context.asyncAssertSuccess(r4 -> {
+                        // update folder 1
+                        try {
+                            final HttpTestHelper.TestHttpServerRequest reqCreate2 = test.http().request(HttpMethod.PUT, "/folders", new JsonObject().put("id",folderId.toString()), createFolder("renamed"));
+                            reqCreate2.response().endJsonHandler(resultCreate2 -> {
+                                explorerTest.ingestJobExecute(true).onComplete(context.asyncAssertSuccess(r5 -> {
+                                    try {
+                                        final HttpTestHelper.TestHttpServerRequest reqList2 = test.http().request(HttpMethod.GET, "/folders/list/all", new JsonObject());
+                                        reqList2.response().endJsonArrayHandler(resultList2 -> {
+                                            context.assertEquals(1, resultList2.size());
+                                            final JsonObject folder1 = resultList2.getJsonObject(0);
+                                            context.assertEquals(folderId.toString(), folder1.getValue("_id"));
+                                            context.assertEquals("renamed", folder1.getString("name"));
+                                            // delete folder
+                                            try {
+                                                final HttpTestHelper.TestHttpServerRequest reqDelete = test.http().request(HttpMethod.DELETE, "/folders", new JsonObject().put("id",folderId.toString()));
+                                                reqDelete.response().endJsonHandler(resultDelete -> {
+                                                    explorerTest.ingestJobExecute(true).onComplete(context.asyncAssertSuccess(r7 -> {
+                                                        try {
+                                                            final HttpTestHelper.TestHttpServerRequest reqList3 = test.http().request(HttpMethod.GET, "/folders/list/all", new JsonObject());
+                                                            reqList3.response().endJsonArrayHandler(resultList3 -> {
+                                                                context.assertEquals(0, resultList3.size());
+                                                                async.complete();
+                                                            });
+                                                            controllerExplorer.list(reqList3.withSession(user1));
+                                                        } catch (Exception e) {
+                                                            context.fail(e);
+                                                        }
+                                                    }));
+                                                });
+                                                controllerExplorer.delete(reqDelete.withSession(user1));
+                                            } catch (Exception e) {
+                                                context.fail(e);
+                                            }
+                                        });
+                                        controllerExplorer.list(reqList2.withSession(user1));
+                                    } catch (Exception e) {
+                                        context.fail(e);
+                                    }
+                                }));
+                            });
+                            controllerExplorer.update(reqCreate2.withSession(user1));
+                        } catch (Exception e) {
+                            context.fail(e);
+                        }
+                    }));
+                });
+                controllerExplorer.add(reqCreate1.withSession(user1));
+            } catch (Exception e) {
+                context.fail(e);
+            }
+        });
+        controllerExplorer.list(reqList1.withSession(user1));
+    }
+
+    /**
+     * <u>GOAL</u> : Ensure that user can see its folders and only its folders
+     *
+     * <u>STEPS</u> :
+     * <ol>
+     *     <li>Create folder1 for user2 </li>
+     *     <li>Create folder2 for user3 </li>
+     *     <li>List folders for user2 => should have 1 folder </li>
+     *     <li>List folders for user3 => should have 1 folder </li>
+     * </ol>
+     * @param context
+     * @throws Exception
+     */
+    @Test
+    public void shouldCreateFolderByUser(TestContext context) throws Exception {
+        final Async async = context.async();
+        final HttpTestHelper.TestHttpServerRequest reqList1 = test.http().request(HttpMethod.GET, "/folders/list/all", new JsonObject());
+        reqList1.response().endJsonArrayHandler(resultList1 -> {
+            context.assertEquals(0, resultList1.size());
+            // create folder 1 for user 2
+            try {
+                final HttpTestHelper.TestHttpServerRequest reqCreate1 = test.http().request(HttpMethod.POST, "/folders", new JsonObject(), createFolder("folder1"));
+                reqCreate1.response().endJsonHandler(resultCreate1 -> {
+                    context.assertNotNull(resultCreate1, "Created folder1 should not be null");
+                    context.assertNotNull(resultCreate1.getValue("_id"), "Created folder1 should have an id");
+                    // create folder 2 for user3
+                    try {
+                        final HttpTestHelper.TestHttpServerRequest reqCreate2 = test.http().request(HttpMethod.POST, "/folders", new JsonObject(), createFolder("folder2"));
+                        reqCreate2.response().endJsonHandler(resultCreate2 -> {
+                            explorerTest.ingestJobExecute(true).onComplete(context.asyncAssertSuccess(r5 -> {
+                                try {
+                                    context.assertNotNull(resultCreate2, "Created folder2 should not be null");
+                                    context.assertNotNull(resultCreate2.getValue("_id"), "Created folder2 should have an id");
+                                    // list for user 2
+                                    final HttpTestHelper.TestHttpServerRequest reqList2 = test.http().request(HttpMethod.GET, "/folders/list/all", new JsonObject());
+                                    reqList2.response().endJsonArrayHandler(resultList2 -> {
+                                        try {
+                                            context.assertEquals(1, resultList2.size());
+                                            // list for user3
+                                            final HttpTestHelper.TestHttpServerRequest reqList3 = test.http().request(HttpMethod.GET, "/folders/list/all", new JsonObject());
+                                            reqList3.response().endJsonArrayHandler(resultList3 -> {
+                                                context.assertEquals(1, resultList3.size());
+                                                async.complete();
+                                            });
+                                            controllerExplorer.list(reqList3.withSession(user3));
+                                        } catch (Exception e) {
+                                            context.fail(e);
+                                        }
+                                    });
+                                    controllerExplorer.list(reqList2.withSession(user2));
+                                } catch (Exception e) {
+                                    context.fail(e);
+                                }
+                            }));
+                        });
+                        controllerExplorer.add(reqCreate2.withSession(user3));
+                    } catch (Exception e) {
+                        context.fail(e);
+                    }
+                });
+                controllerExplorer.add(reqCreate1.withSession(user2));
+            } catch (Exception e) {
+                context.fail(e);
+            }
+        });
+        controllerExplorer.list(reqList1.withSession(user2));
+    }
+
+    /**
+     * <u>GOAL</u> : Ensure that resources are attached to folder
+     *
+     * <u>STEPS</u> :
+     * <ol>
+     *     <li>Create folder1 for user4 </li>
+     *     <li>Create blog1 for user4 at root</li>
+     *     <li>Create blog2 and blog3 for user4 in folder1</li>
+     *     <li>List all folders => Should have 1 folder with 2 blogs inside </li>
+     * </ol>
+     * @param context
+     * @throws Exception
+     */
+    @Test
+    public void shouldFetchResourceByFolders(TestContext context) throws Exception {
+        final Async async = context.async();
+        // create folder1 for user4
+        final HttpTestHelper.TestHttpServerRequest reqCreate1 = test.http().request(HttpMethod.POST, "/folders", new JsonObject(), createFolder("folder1"));
+        reqCreate1.response().endJsonHandler(resultCreate1 -> {
+            context.assertNotNull(resultCreate1, "Created folder1 should not be null");
+            context.assertNotNull(resultCreate1.getValue("_id"), "Created folder1 should have an id");
+            final Long folderId = NumberUtils.toLong(resultCreate1.getValue("_id").toString());
+            explorerTest.ingestJobExecute(true).onComplete(context.asyncAssertSuccess(r0 -> {
+                // create blog1 for user4 at root
+                final JsonObject b1 = createBlog("blog1");
+                blogService.create(b1, user4, false, test.asserts().asyncAssertSuccessEither(context.asyncAssertSuccess(rb1 -> {
+                    // create blog2 for user4 in folder1
+                    final JsonObject b2 = createBlog("blog2").put("folder", folderId);
+                    blogService.create(b2, user4, false, test.asserts().asyncAssertSuccessEither(context.asyncAssertSuccess(rb2 -> {
+                        // create blog3 for user4 in folder1
+                        final JsonObject b3 = createBlog("blog3").put("folder", folderId);
+                        blogService.create(b3, user4, false, test.asserts().asyncAssertSuccessEither(context.asyncAssertSuccess(rb3 -> {
+                            // wait pending task
+                            blogPlugin.getCommunication().waitPending().onComplete(context.asyncAssertSuccess(r3 -> {
+                                explorerTest.ingestJobExecute(true).onComplete(context.asyncAssertSuccess(r4 -> {
+                                    try {
+                                        // fetch folders of user4
+                                        final HttpTestHelper.TestHttpServerRequest reqList1 = test.http().request(HttpMethod.GET, "/folders/list/all", new JsonObject());
+                                        reqList1.response().endJsonArrayHandler(resultList1 -> {
+                                            context.assertEquals(1, resultList1.size());
+                                            final JsonObject folder4 = resultList1.getJsonObject(0);
+                                            context.assertEquals(2, folder4.getJsonArray("ressourceIds").size());
+                                            async.complete();
+                                        });
+                                        controllerExplorer.list(reqList1.withSession(user4));
+                                    } catch (Exception e) {
+                                        context.fail(e);
+                                    }
+                                }));
+                            }));
+                        })));
+                    })));
+                })));
+            }));
+        });
+        controllerExplorer.add(reqCreate1.withSession(user4));
+    }
+}


### PR DESCRIPTION
# Description

Un Controlleur Proxy a été ajouté à la place de FolderController. En fonction de la config "use-explorer-folder-api" il va charger:
- le controlleur legacy (qui tape mongodb) si la config est à false
- le nouveau controlleur qui appelle l'explorateur via le bus si la config est à true

Deux config ont été ajouté:
- use-explorer-folder-api: par défaut à true => si true utilise les API de l'explorateur
- use-explorer-ui: par défaut à true -> si true affiche la nouvelle UI abondance si false affiche l'ancienne interface

## Fixes

Ticket jira #WB2-644

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X ] New feature (MINOR)


## Tests

Des TU sont dispo dans le module blog:
- Création d'arbo de dossiers
- Crud de dossiers
- Récupération de dossier par utilisateur
- Récupération des ressources rattachés aux dossiers

# Reminder

- Security flaws (bros before security holes)
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ X] All done ! :smiley: