### PR TITLE
[ODE] Importer les ressources importées depuis workspace

### DIFF
--- a/src/main/java/org/entcore/blog/Blog.java
+++ b/src/main/java/org/entcore/blog/Blog.java
@@ -35,13 +35,19 @@ import org.entcore.blog.services.impl.BlogRepositoryEvents;
 import org.entcore.blog.services.impl.DefaultBlogService;
 import org.entcore.blog.services.impl.DefaultPostService;
 import org.entcore.common.events.EventStoreFactory;
+import org.entcore.common.explorer.IExplorerPluginClient;
+import org.entcore.common.explorer.impl.ExplorerRepositoryEvents;
 import org.entcore.common.http.BaseServer;
 import org.entcore.common.mongodb.MongoDbConf;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class Blog extends BaseServer {
 
     public static final String APPLICATION = "blog";
     public static final String BLOG_TYPE = "blog";
+    public static final String POST_TYPE = "post";
     public static final String POSTS_COLLECTION = "posts";
     public static final String BLOGS_COLLECTION = "blogs";
     BlogExplorerPlugin blogPlugin;
@@ -56,7 +62,12 @@ public class Blog extends BaseServer {
         EventStoreFactory eventStoreFactory = EventStoreFactory.getFactory();
         eventStoreFactory.setVertx(vertx);
 
-        setRepositoryEvents(new BlogRepositoryEvents(vertx));
+        final Map<String, IExplorerPluginClient> pluginClientPerCollection = new HashMap<>();
+        pluginClientPerCollection.put(BLOGS_COLLECTION, IExplorerPluginClient.withBus(vertx, APPLICATION, BLOG_TYPE));
+        pluginClientPerCollection.put(POSTS_COLLECTION, IExplorerPluginClient.withBus(vertx, APPLICATION, POST_TYPE));
+        setRepositoryEvents(new ExplorerRepositoryEvents(
+                new BlogRepositoryEvents(vertx),
+                pluginClientPerCollection));
 
         if (config.getBoolean("searching-event", true)) {
             setSearchingEvents(new BlogSearchingEvents());

--- a/src/main/java/org/entcore/blog/explorer/PostExplorerPlugin.java
+++ b/src/main/java/org/entcore/blog/explorer/PostExplorerPlugin.java
@@ -1,7 +1,6 @@
 package org.entcore.blog.explorer;
 
 import com.mongodb.QueryBuilder;
-import fr.wseduc.mongodb.MongoDb;
 import fr.wseduc.mongodb.MongoQueryBuilder;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -15,7 +14,6 @@ import org.entcore.common.explorer.ExplorerMessage;
 import org.entcore.common.explorer.impl.ExplorerSubResourceMongo;
 import org.entcore.common.user.UserInfos;
 
-import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -38,7 +36,7 @@ public class PostExplorerPlugin extends ExplorerSubResourceMongo {
         user.setUserId( author.getString("userId"));
         user.setUsername(author.getString("username"));
         user.setLogin(author.getString("login"));
-        return Optional.ofNullable(user);
+        return Optional.of(user);
     }
 
     @Override
@@ -59,25 +57,29 @@ public class PostExplorerPlugin extends ExplorerSubResourceMongo {
 
     @Override
     public String getEntityType() {
-        return "post";
+        return Blog.POST_TYPE;
     }
 
     @Override
     protected String getParentId(JsonObject jsonObject) {
         final JsonObject blogRef = jsonObject.getJsonObject("blog");
-        final String blogId = blogRef.getString("$id");
-        return blogId;
+        return blogRef.getString("$id");
     }
+
 
     @Override
     protected Future<ExplorerMessage> doToMessage(final ExplorerMessage message, final JsonObject source) {
         final String id = source.getString("_id");
         message.withVersion(System.currentTimeMillis());
-        message.withSubResourceHtml(id, source.getString("content",""), source.getLong("version", 0l));
+        message.withSubResourceHtml(id, source.getString("content",""), source.getLong("version", 0L));
         return Future.succeededFuture(message);
     }
 
     @Override
     protected String getCollectionName() { return COLLECTION; }
+
+    protected String getParentColumn() {
+        return "blog.$id";
+    }
 
 }

--- a/src/test/java/org/entcore/blog/BlogExplorerPluginClientTest.java
+++ b/src/test/java/org/entcore/blog/BlogExplorerPluginClientTest.java
@@ -1,6 +1,5 @@
 package org.entcore.blog;
 
-import com.opendigitaleducation.explorer.ingest.IngestJobMetricsRecorderFactory;
 import com.opendigitaleducation.explorer.tests.ExplorerTestHelper;
 import fr.wseduc.mongodb.MongoDb;
 import fr.wseduc.webutils.security.SecuredAction;
@@ -12,6 +11,7 @@ import io.vertx.ext.mongo.MongoClient;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import static java.util.Collections.emptySet;
 import org.entcore.blog.controllers.PostController;
 import org.entcore.blog.explorer.BlogExplorerPlugin;
 import org.entcore.blog.explorer.BlogFoldersExplorerPlugin;
@@ -23,6 +23,7 @@ import org.entcore.blog.services.impl.DefaultPostService;
 import org.entcore.common.explorer.IExplorerFolderTree;
 import org.entcore.common.explorer.IExplorerPluginClient;
 import org.entcore.common.explorer.IExplorerPluginCommunication;
+import org.entcore.common.explorer.to.ExplorerReindexResourcesRequest;
 import org.entcore.common.mongodb.MongoDbConf;
 import org.entcore.common.user.UserInfos;
 import org.entcore.test.TestHelper;
@@ -33,7 +34,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.MongoDBContainer;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
 @RunWith(VertxUnitRunner.class)
 public class BlogExplorerPluginClientTest {
@@ -165,7 +169,7 @@ public class BlogExplorerPluginClientTest {
                                 return saveFolder("folder1", user, Optional.empty()).compose(folder1 -> {
                                     final String folder1Id = folder1.getString("_id");
                                     return saveFolder("folder2", user, Optional.ofNullable(folder1Id), blog3Id).compose(folder2 -> {
-                                        return client.getForIndexation(admin, Optional.empty(), Optional.empty(), new HashSet<>(), true).onComplete(context.asyncAssertSuccess(indexation -> {
+                                        return client.reindex(admin, new ExplorerReindexResourcesRequest(null, null, emptySet(), true, emptySet())).onComplete(context.asyncAssertSuccess(indexation -> {
                                             context.assertEquals(3, indexation.nbBatch);
                                             context.assertEquals(3, indexation.nbMessage);
                                             explorerTest.getCommunication().waitPending().onComplete(context.asyncAssertSuccess(pending -> {


### PR DESCRIPTION
# Description

Appel au nouveau `RepositoryEvents` de l'EUR pour indexer les resources importés par workspace.

## Fixes

WB2-959

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

# Tests
1. Export an archive containing blogs from recette or preprod
2. Import this archive in the targeted ENT
3. Imported resources are visible in Blog homepage

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: