### PR TITLE
[ODE] Ne pas réécrire les droits de partages après la modification des propriétés d'une ressource #365

### DIFF
--- a/src/main/java/org/entcore/blog/explorer/BlogExplorerPlugin.java
+++ b/src/main/java/org/entcore/blog/explorer/BlogExplorerPlugin.java
@@ -73,14 +73,17 @@ public class BlogExplorerPlugin extends ExplorerPluginResourceMongo {
     @Override
     protected Future<ExplorerMessage> doToMessage(final ExplorerMessage message, final JsonObject source) {
         final Optional<String> creatorId = getCreatorForModel(source).map(e -> e.getUserId());
-        final ShareModel shareModel = new ShareModel(source.getJsonArray("shared", new JsonArray()), securedActions, creatorId);
         final JsonObject custom = new JsonObject().put("slug", source.getString("slug", ""));
         custom.put("publish-type", source.getString("publish-type", ""));
         message.withName(source.getString("title", ""));
         message.withContent(source.getString("description", ""), ExplorerMessage.ExplorerContentType.Html);
         message.withPublic("PUBLIC".equals(source.getString("visibility")));
         message.withTrashed(source.getBoolean("trashed", false));
-        message.withShared(shareModel);
+        // "shared" only has meaning if it was explicitly set, otherwise it will reset the resources' shares
+        if(source.containsKey("shared")) {
+            final ShareModel shareModel = new ShareModel(source.getJsonArray("shared", new JsonArray()), securedActions, creatorId);
+            message.withShared(shareModel);
+        }
         message.withThumbnail(source.getString("thumbnail"));
         message.withDescription(source.getString("description"));
         message.withCustomFields(custom);


### PR DESCRIPTION
# Description

Lors de la modification des propriétés d'une resource, les droits de partages sont vidés parce que la valeur par défaut des droits est un tableau vide, qui est interprété par l'EUR comme le fait de vider les droits de partages. La valeur par défaut `[]` a donc été remplacé par un `null` qui a l'effet escompté (ne rien faire sur les partages quand on n'a pas d'informations à leur sujet).

## Fixes

WB2-996

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Tests

Le test du ticket

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: