### PR TITLE
WB-2008 providing plain text content to explorer for indexation

### DIFF
--- a/src/main/java/org/entcore/blog/Blog.java
+++ b/src/main/java/org/entcore/blog/Blog.java
@@ -83,12 +83,13 @@ public class Blog extends BaseServer {
         conf.setCollection(BLOGS_COLLECTION);
         conf.setResourceIdLabel("id");
 
-        blogPlugin = BlogExplorerPlugin.create(securedActions);
-        final PostExplorerPlugin postPlugin = blogPlugin.postPlugin();
-        final MongoDb mongo = MongoDb.getInstance();
         ContentTransformerFactoryProvider.init(vertx);
         final JsonObject contentTransformerConfig = getContentTransformerConfig(vertx).orElse(null);
         IContentTransformerClient contentTransformerClient = ContentTransformerFactoryProvider.getFactory("blog", contentTransformerConfig).create();
+
+        blogPlugin = BlogExplorerPlugin.create(securedActions);
+        final PostExplorerPlugin postPlugin = blogPlugin.postPlugin();
+        final MongoDb mongo = MongoDb.getInstance();
         final PostService postService = new DefaultPostService(mongo,config.getInteger("post-search-word-min-size", 4), PostController.LIST_ACTION, postPlugin, contentTransformerClient);
         final BlogService blogService = new DefaultBlogService(mongo, postService, config.getInteger("blog-paging-size", 30),
                 config.getInteger("blog-search-word-min-size", 4), blogPlugin);

--- a/src/main/java/org/entcore/blog/explorer/PostExplorerPlugin.java
+++ b/src/main/java/org/entcore/blog/explorer/PostExplorerPlugin.java
@@ -71,7 +71,11 @@ public class PostExplorerPlugin extends ExplorerSubResourceMongo {
     protected Future<ExplorerMessage> doToMessage(final ExplorerMessage message, final JsonObject source) {
         final String id = source.getString("_id");
         message.withVersion(System.currentTimeMillis());
-        message.withSubResourceHtml(id, source.getString("content",""), source.getLong("version", 0L));
+        if (source.containsKey("contentPlain")) {
+            message.withSubResourceContent(id, source.getString("contentPlain"), ExplorerMessage.ExplorerContentType.Text, source.getLong("version", 0L));
+        } else {
+            message.withSubResourceContent(id, source.getString("content", ""), ExplorerMessage.ExplorerContentType.Html, source.getLong("version", 0L));
+        }
         return Future.succeededFuture(message);
     }
 

--- a/src/main/java/org/entcore/blog/explorer/PostExplorerPlugin.java
+++ b/src/main/java/org/entcore/blog/explorer/PostExplorerPlugin.java
@@ -68,18 +68,6 @@ public class PostExplorerPlugin extends ExplorerSubResourceMongo {
 
 
     @Override
-    protected Future<ExplorerMessage> doToMessage(final ExplorerMessage message, final JsonObject source) {
-        final String id = source.getString("_id");
-        message.withVersion(System.currentTimeMillis());
-        if (source.containsKey("contentPlain")) {
-            message.withSubResourceContent(id, source.getString("contentPlain"), ExplorerMessage.ExplorerContentType.Text, source.getLong("version", 0L));
-        } else {
-            message.withSubResourceContent(id, source.getString("content", ""), ExplorerMessage.ExplorerContentType.Html, source.getLong("version", 0L));
-        }
-        return Future.succeededFuture(message);
-    }
-
-    @Override
     protected String getCollectionName() { return COLLECTION; }
 
     protected String getParentColumn() {

--- a/src/main/java/org/entcore/blog/services/impl/DefaultPostService.java
+++ b/src/main/java/org/entcore/blog/services/impl/DefaultPostService.java
@@ -175,7 +175,7 @@ public class DefaultPostService implements PostService {
 					// transformation of html content into jsonContent
 					contentTransformerResponseFuture = contentTransformerClient.transform(
 							new ContentTransformerRequest(
-									new HashSet<>(Arrays.asList(ContentTransformerFormat.JSON, ContentTransformerFormat.PLAINTEXT)),
+									new HashSet<>(Arrays.asList(ContentTransformerFormat.JSON, ContentTransformerFormat.PLAINTEXT, ContentTransformerFormat.HTML)),
 									validatedPost.getInteger("contentVersion", 0),
 									validatedPost.getString("content"),
 									null));
@@ -210,6 +210,7 @@ public class DefaultPostService implements PostService {
 						} else {
 							validatedPost.put("contentVersion", response.result().getContentVersion());
 							validatedPost.put("jsonContent", response.result().getJsonContent());
+							validatedPost.put("content", response.result().getCleanHtml());
 							validatedPost.put("contentPlain", response.result().getPlainTextContent());
 						}
 					}

--- a/src/test/java/org/entcore/blog/PostServiceContentTransformerTest.java
+++ b/src/test/java/org/entcore/blog/PostServiceContentTransformerTest.java
@@ -92,7 +92,7 @@ public class PostServiceContentTransformerTest {
             postService.get(blogId, postId, PostService.StateType.DRAFT, test.asserts().asyncAssertSuccessEither(context.asyncAssertSuccess(postGet -> {
                 context.assertEquals(post1.getString("content"), postGet.getString("content"));
                 context.assertEquals(1, postGet.getInteger("contentVersion"));
-                context.assertEquals("<p> value </p>", postGet.getJsonObject("jsonContent").getString("key"));
+                context.assertEquals("value", postGet.getJsonObject("jsonContent").getString("content"));
                 async.complete();
             })));
         })));
@@ -112,7 +112,7 @@ public class PostServiceContentTransformerTest {
             postService.get(blogId, postId, PostService.StateType.DRAFT, test.asserts().asyncAssertSuccessEither(context.asyncAssertSuccess(postGet -> {
                 context.assertEquals(post2.getString("content"), postGet.getString("content"));
                 context.assertEquals(1, postGet.getInteger("contentVersion"));
-                context.assertEquals("<p> value </p>", postGet.getJsonObject("jsonContent").getString("key"));
+                context.assertEquals("value", postGet.getJsonObject("jsonContent").getString("content"));
                 async.complete();
             })));
         })));
@@ -122,12 +122,12 @@ public class PostServiceContentTransformerTest {
 
         @Override
         public Future<ContentTransformerResponse> transform(ContentTransformerRequest contentTransformerRequest) {
-            return Future.succeededFuture(new ContentTransformerResponse(1, "<p> value </p>", new JsonObject().put("key", "<p> value </p>").getMap(), "value", null, null));
+            return Future.succeededFuture(new ContentTransformerResponse(1, contentTransformerRequest.getHtmlContent(), new JsonObject().put("content", "value").getMap(), "value", contentTransformerRequest.getHtmlContent(), null));
         }
     }
 
 
     static JsonObject createPost(final String name) {
-        return new JsonObject().put("title", name).put("content", "description" + name).put("state", "PUBLISHED");
+        return new JsonObject().put("title", name).put("content", "<p> description" + name + " </p>").put("state", "PUBLISHED");
     }
 }

--- a/src/test/java/org/entcore/blog/PostServiceContentTransformerTest.java
+++ b/src/test/java/org/entcore/blog/PostServiceContentTransformerTest.java
@@ -122,7 +122,7 @@ public class PostServiceContentTransformerTest {
 
         @Override
         public Future<ContentTransformerResponse> transform(ContentTransformerRequest contentTransformerRequest) {
-            return Future.succeededFuture(new ContentTransformerResponse(1, "<p> value </p>", new JsonObject().put("key", "<p> value </p>").getMap()));
+            return Future.succeededFuture(new ContentTransformerResponse(1, "<p> value </p>", new JsonObject().put("key", "<p> value </p>").getMap(), "value", null, null));
         }
     }
 


### PR DESCRIPTION
Ticket : https://edifice-community.atlassian.net/browse/WB-2008

Dans le cas de la création ou de la mise à jour de contenu de billets de blog, on récupère une version **plain text** (et non plus html) du contenu qui sera désormais transmis à l'explorateur pour l'indexation. Ce contenu plain text sera stocké dans un champ **content** de la base ES.

Ont dû être mis à jour :
- entcore : https://github.com/opendigitaleducation/entcore/pull/391
- explorer : https://github.com/opendigitaleducation/explorer/pull/27

Tests : 
- mise à jour des tests mixtes associés au plugin explorateur
- tests dev manuels