### PR TITLE
WB-2007 returning only content version and cleaned html to frontend

### DIFF
--- a/src/test/java/org/entcore/blog/BlogExplorerPluginTest.java
+++ b/src/test/java/org/entcore/blog/BlogExplorerPluginTest.java
@@ -221,7 +221,7 @@ public class BlogExplorerPluginTest {
                             context.assertNotNull(postModel.getValue("author"));
                             context.assertNotNull(postModel.getNumber("views"));
                             postService.get(id, postId, PostService.StateType.DRAFT, test.asserts().asyncAssertSuccessEither(context.asyncAssertSuccess(postGet -> {
-                                context.assertEquals(post1.getString("content"), postGet.getString("content"));
+                                context.assertEquals("<p>clean html</p>"+post1.getString("content"), postGet.getString("content"));
                                 async.complete();
                             })));
                         })));
@@ -323,7 +323,7 @@ public class BlogExplorerPluginTest {
                             context.assertEquals(1, fetch1.size());
                             blogPlugin.getShareInfo(blogId).onComplete(context.asyncAssertSuccess(shareEvt->{
                                 context.assertEquals(1, shareEvt.size());
-                                context.assertTrue(shareEvt.getJsonObject(0).containsKey("userId"));
+                                context.assertTrue(shareEvt.contains("user:user_share1:read"));
                                 async.complete();
                             }));
                         }));
@@ -358,7 +358,7 @@ public class BlogExplorerPluginTest {
                             context.assertEquals(1, fetch1.size());
                             blogPlugin.getShareInfo(blogId).onComplete(context.asyncAssertSuccess(shareEvt->{
                                 context.assertEquals(1, shareEvt.size());
-                                context.assertTrue(shareEvt.getJsonObject(0).containsKey("groupId"));
+                                context.assertTrue(shareEvt.contains("group:group_share2:read"));
                                 async.complete();
                             }));
                         }));
@@ -419,7 +419,7 @@ public class BlogExplorerPluginTest {
 
         @Override
         public Future<ContentTransformerResponse> transform(ContentTransformerRequest contentTransformerRequest) {
-            return Future.succeededFuture(new ContentTransformerResponse(1, contentTransformerRequest.getHtmlContent(), null, contentTransformerRequest.getHtmlContent(), null, null));
+            return Future.succeededFuture(new ContentTransformerResponse(1, contentTransformerRequest.getHtmlContent(), null, contentTransformerRequest.getHtmlContent(), "<p>clean html</p>"+contentTransformerRequest.getHtmlContent(), null));
         }
     }
 }


### PR DESCRIPTION
Ticket associé : https://edifice-community.atlassian.net/browse/WB-2007

Petite adaptation consistant à renvoyer au front seulement le contenu HTML "nettoyé", étant donné qu'il est le seul format à être consommé pour l'instant.
Les contenus aux formats JSON & PLAIN sont toutefois bien persistés en base.

Tests : 
-  adaptation & affinage des tests mixtes concernés
- correction de tests mixtes non liés mais qui ne passaient plus [ici](https://github.com/opendigitaleducation/blog/blob/c4e77cf53cf6c62097ad58224f19f765feeaabcf/src/test/java/org/entcore/blog/BlogExplorerPluginTest.java#L361C39-L361C39) et [ici](https://github.com/opendigitaleducation/blog/blob/c4e77cf53cf6c62097ad58224f19f765feeaabcf/src/test/java/org/entcore/blog/BlogExplorerPluginTest.java#L326) 
- tests manuels dev