### PR TITLE
[EDIFICE] Ajout d'un cache au service de transformation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ package-lock.json
 gradle/
 gradlew*
 rev-manifest.json
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -83,10 +83,31 @@ task generateCommitId {
     project.ext.set('buildTime', formattedDate)
   }
 }
+
+task gatherDependenciesBuildInformation {
+  doLast {
+    // Filter dependencies by group and name
+    def selectedDependencies = configurations.compile
+            .findAll { it.name.startsWith("web-utils") }
+
+    // Iterate over the selected dependencies
+    selectedDependencies.each { File dependency ->
+      def jarFile = new java.util.jar.JarFile(dependency)
+      def dependencyManifest = jarFile.getManifest()
+      def depName = dependency.name.replaceAll("^(.*?)-\\d+\\..+\$", "\$1").replace("-", "")
+      project.ext.set(depName + '_commitId', dependencyManifest.mainAttributes.getValue('SCM-Commit-Id'))
+      project.ext.set(depName + '_branch', dependencyManifest.mainAttributes.getValue('SCM-Branch'))
+      project.ext.set(depName + '_buildTime', dependencyManifest.mainAttributes.getValue('Build-Time'))
+      // Close the JarFile
+      jarFile.close()
+    }
+  }
+}
 compileJava {
   sourceCompatibility = project.sourceCompatibility
   targetCompatibility = project.targetCompatibility
   dependsOn generateCommitId
+  dependsOn gatherDependenciesBuildInformation
 }
 
 compileTestJava {
@@ -113,7 +134,10 @@ jar {
         "Main-Verticle": "service:mod",
         "SCM-Commit-Id": "${-> project.ext.commitId}",
         "SCM-Branch": "${-> project.ext.branchName}",
-        "Build-Time": "${-> project.ext.buildTime}"
+        "Build-Time": "${-> project.ext.buildTime}",
+        "Web-Utils-SCM-Commit-Id": "${-> project.ext.webutils_commitId}",
+        "Web-Utils-SCM-Branch": "${-> project.ext.webutils_branch}",
+        "Web-Utils-Build-Time": "${-> project.ext.webutils_buildTime}"
         )
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,7 @@ toolsVersion=2.0.0-final
 junitVersion=4.10
 
 # compile lib
-entCoreVersion=4.11-b2school-SNAPSHOT
+entCoreVersion=4.12-b2school-SNAPSHOT
 explorerVersion=1.2-SNAPSHOT
 
 runModsArgs=

--- a/src/main/java/org/entcore/blog/controllers/PostController.java
+++ b/src/main/java/org/entcore/blog/controllers/PostController.java
@@ -164,19 +164,19 @@ public class PostController extends BaseController {
 
 	@ApiDoc("Gets a post by id iff the post belongs to the blog whose id has been specified in blogId parameter and " +
 			"if the given state is the expected one. " +
-			"The query param oldFormat is to be set to true if the content field of the returned post must be in its original (i.e." +
+			"The query param originalFormat is to be set to true if the content field of the returned post must be in its original (i.e." +
 			"if we want the content unaltered by the rich content converter) ")
 	@Get("/post/:blogId/:postId")
 	@SecuredAction(value = "blog.read", type = ActionType.RESOURCE)
 	public void get(final HttpServerRequest request) {
 		final String blogId = request.params().get("blogId");
 		final String postId = request.params().get("postId");
-		final boolean oldFormat = "true".equalsIgnoreCase(request.params().get("oldFormat"));
+		final boolean originalFormat = "true".equalsIgnoreCase(request.params().get("originalFormat"));
 		if (blogId == null || blogId.trim().isEmpty() || postId == null || postId.trim().isEmpty()) {
 			badRequest(request);
 			return;
 		}
-		final PostFilter filter = new PostFilter(blogId, postId, oldFormat, BlogResourcesProvider.getStateType(request));
+		final PostFilter filter = new PostFilter(blogId, postId, originalFormat, BlogResourcesProvider.getStateType(request));
 		post.get(filter).onComplete(defaultAsyncResultResponseHandler(request));
 	}
 

--- a/src/main/java/org/entcore/blog/services/PostService.java
+++ b/src/main/java/org/entcore/blog/services/PostService.java
@@ -23,6 +23,8 @@
 package org.entcore.blog.services;
 
 import fr.wseduc.webutils.Either;
+import io.vertx.core.Future;
+import org.entcore.blog.to.PostFilter;
 import org.entcore.common.user.UserInfos;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
@@ -47,7 +49,12 @@ public interface PostService {
 
 	void delete(UserInfos user, String blogId, String postId, Handler<Either<String, JsonObject>> result);
 
-	void get(String blogId, String postId, StateType state, Handler<Either<String, JsonObject>> result);
+	/**
+	 *
+	 * @param filter Filter that describes the desired post.
+	 * @return Fetched post iff the post with the specified id and state belongs to the blog with the specified id.
+	 */
+	Future<JsonObject> get(final PostFilter filter);
 
 	default void list(String blogId, UserInfos user, Integer page, int limit, String search, final Set<String> states, Handler<Either<String, JsonArray>> result){
 		list(blogId, user, page, limit, search, states, false, result);

--- a/src/main/java/org/entcore/blog/services/impl/DefaultPostService.java
+++ b/src/main/java/org/entcore/blog/services/impl/DefaultPostService.java
@@ -60,6 +60,7 @@ public class DefaultPostService implements PostService {
 
 	private final MongoDb mongo;
 	protected static final String POST_COLLECTION = "posts";
+	public static final String TRANSFORMED_CONTENT_DB_FIELD_NAME = "transformed_content";
 	private static final JsonObject defaultKeys = new JsonObject()
 			.put("author", 1)
 			.put("title", 1)
@@ -71,9 +72,8 @@ public class DefaultPostService implements PostService {
 			.put("views", 1)
 			.put("firstPublishDate", 1)
 			.put("contentVersion", 1);
-	private static final JsonObject keysWithTransformedContent = defaultKeys.copy().put("transformed_content", 1);
+	private static final JsonObject keysWithTransformedContent = defaultKeys.copy().put(TRANSFORMED_CONTENT_DB_FIELD_NAME, 1);
 
-	public static final String TRANSFORMED_CONTENT_DB_FIELD_NAME = "transformed_content";
 
 	private final int searchWordMinSize;
 	private final PostExplorerPlugin plugin;
@@ -339,7 +339,7 @@ public class DefaultPostService implements PostService {
 			if(!originalFormatRequested && fetchedPost.getInteger("contentVersion", -1) == 0 && fetchedPost.containsKey(TRANSFORMED_CONTENT_DB_FIELD_NAME)) {
 				fetchedPost.put("content", fetchedPost.getString(TRANSFORMED_CONTENT_DB_FIELD_NAME));
 			}
-			fetchedPost.remove("original_content"); // Remove this so it doesn't appear in the response to the client
+			fetchedPost.remove(TRANSFORMED_CONTENT_DB_FIELD_NAME); // Remove this so it doesn't appear in the response to the client
 			return fetchedPost;
 		});
 	}

--- a/src/main/java/org/entcore/blog/to/PostFilter.java
+++ b/src/main/java/org/entcore/blog/to/PostFilter.java
@@ -40,7 +40,7 @@ public class PostFilter {
   @JsonCreator
   public PostFilter(@JsonProperty("blogId") final String blogId,
                     @JsonProperty("postId") final String postId,
-                    @JsonProperty("oldFormat") final boolean originalFormat,
+                    @JsonProperty("originalFormat") final boolean originalFormat,
                     @JsonProperty("state") final PostService.StateType state) {
 
 

--- a/src/main/java/org/entcore/blog/to/PostFilter.java
+++ b/src/main/java/org/entcore/blog/to/PostFilter.java
@@ -1,0 +1,52 @@
+package org.entcore.blog.to;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.entcore.blog.services.PostService;
+
+public class PostFilter {
+  /** Id of the blog which includes the desired post. */
+  private final String blogId;
+  /** Id of the desired post. */
+  private final String postId;
+  /** {@code true} if we want the content of the post to be returned as-is (i.e. without TipTap conversion). */
+  private final boolean originalFormat;
+  /** State that the post must have. */
+  private final PostService.StateType state;
+
+
+  public String getBlogId() {
+    return blogId;
+  }
+
+  public String getPostId() {
+    return postId;
+  }
+
+  public boolean isOriginalFormat() {
+    return originalFormat;
+  }
+
+  public PostService.StateType getState() {
+    return state;
+  }
+
+  /**
+   * @param blogId Id of the blog which includes the desired post
+   * @param postId Id of the desired post
+   * @param state State that the post must have
+   * @param originalFormat {@code true} if we want the content of the post to be returned as it was last updated by the user (i.e. without TipTap conversion)
+   */
+  @JsonCreator
+  public PostFilter(@JsonProperty("blogId") final String blogId,
+                    @JsonProperty("postId") final String postId,
+                    @JsonProperty("oldFormat") final boolean originalFormat,
+                    @JsonProperty("state") final PostService.StateType state) {
+
+
+    this.blogId = blogId;
+    this.postId = postId;
+    this.originalFormat = originalFormat;
+    this.state = state;
+  }
+}

--- a/src/test/java/org/entcore/blog/BlogExplorerPluginTest.java
+++ b/src/test/java/org/entcore/blog/BlogExplorerPluginTest.java
@@ -20,6 +20,7 @@ import org.entcore.blog.services.BlogService;
 import org.entcore.blog.services.PostService;
 import org.entcore.blog.services.impl.DefaultBlogService;
 import org.entcore.blog.services.impl.DefaultPostService;
+import org.entcore.blog.to.PostFilter;
 import org.entcore.common.explorer.IExplorerPluginCommunication;
 import org.entcore.common.mongodb.MongoDbConf;
 import org.entcore.common.share.ShareService;
@@ -220,10 +221,12 @@ public class BlogExplorerPluginTest {
                             context.assertNotNull(postModel.getValue("modified"));
                             context.assertNotNull(postModel.getValue("author"));
                             context.assertNotNull(postModel.getNumber("views"));
-                            postService.get(id, postId, PostService.StateType.DRAFT, test.asserts().asyncAssertSuccessEither(context.asyncAssertSuccess(postGet -> {
+                            postService.get(new PostFilter(id, postId, false, PostService.StateType.DRAFT))
+                            .onSuccess(postGet -> {
                                 context.assertEquals("<p>clean html</p>"+post1.getString("content"), postGet.getString("content"));
                                 async.complete();
-                            })));
+                            })
+                            .onFailure(context::fail);
                         })));
                     }));
                 }));

--- a/src/test/java/org/entcore/blog/PostServiceContentTransformerTest.java
+++ b/src/test/java/org/entcore/blog/PostServiceContentTransformerTest.java
@@ -5,11 +5,13 @@ import com.opendigitaleducation.explorer.ingest.IngestJobMetricsRecorderFactory;
 import com.opendigitaleducation.explorer.tests.ExplorerTestHelper;
 import fr.wseduc.mongodb.MongoDb;
 import fr.wseduc.mongodb.MongoQueryBuilder;
+import fr.wseduc.mongodb.MongoUpdateBuilder;
 import fr.wseduc.transformer.IContentTransformerClient;
 import fr.wseduc.transformer.to.ContentTransformerRequest;
 import fr.wseduc.transformer.to.ContentTransformerResponse;
 import fr.wseduc.webutils.security.SecuredAction;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mongo.MongoClient;
 import io.vertx.ext.unit.Async;
@@ -18,7 +20,9 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.entcore.blog.controllers.PostController;
 import org.entcore.blog.explorer.BlogExplorerPlugin;
 import org.entcore.blog.explorer.PostExplorerPlugin;
+import org.entcore.blog.services.BlogService;
 import org.entcore.blog.services.PostService;
+import org.entcore.blog.services.impl.DefaultBlogService;
 import org.entcore.blog.services.impl.DefaultPostService;
 import org.entcore.common.explorer.IExplorerPluginCommunication;
 import org.entcore.common.mongodb.MongoDbConf;
@@ -36,6 +40,9 @@ import org.testcontainers.containers.Neo4jContainer;
 import java.util.HashMap;
 import java.util.Map;
 
+import static fr.wseduc.mongodb.MongoDbAPI.isOk;
+import static org.entcore.blog.BlogExplorerPluginClientTest.createBlog;
+
 
 @RunWith(VertxUnitRunner.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -45,6 +52,7 @@ public class PostServiceContentTransformerTest {
      * Class to test
      */
     static PostService postService;
+    static BlogService blogService;
     private static final TestHelper test = TestHelper.helper();
     @ClassRule
     public static Neo4jContainer<?> neo4jContainer = test.database().createNeo4jContainer();
@@ -55,10 +63,12 @@ public class PostServiceContentTransformerTest {
     static MongoDb mongoDb;
     static BlogExplorerPlugin blogPlugin;
     static PostExplorerPlugin postPlugin;
-    static IContentTransformerClient contentTransformerClient;
+    static DummyContentTransformerClient contentTransformerClient;
     static final int POST_SEARCH_WORD = 4;
     static Map<String, Object> data = new HashMap<>();
     static final UserInfos user = test.directory().generateUser("user");
+
+    static final int nbTimesGetSamePost = 10;
 
     @BeforeClass
     public static void setUp(TestContext context) throws Exception {
@@ -76,8 +86,8 @@ public class PostServiceContentTransformerTest {
         postPlugin = blogPlugin.postPlugin();
         contentTransformerClient = new DummyContentTransformerClient();
         data.put("BLOGID1", "blog-id-1");
-
         postService = new DefaultPostService(mongoDb, POST_SEARCH_WORD, PostController.LIST_ACTION, postPlugin, contentTransformerClient);
+        blogService = new DefaultBlogService(mongoDb, postService, 20, 3, blogPlugin);
     }
 
 
@@ -131,16 +141,136 @@ public class PostServiceContentTransformerTest {
         })));
     }
 
+    /**
+     * <h1>Goal</h1>
+     * <p>Ensure that the transformer is called only once for legacy content.</p>
+     * <h1>Steps</h1>
+     * <ol>
+     *   <li>Create a blog</li>
+     *   <li>Create a post</li>
+     *   <li>Remove the fields of the created post which allows us to detect that a content is produced by the new editor</li>
+     *   <li>Call successively n times /get</li>
+     *   <li>Verify that we get a coherent result</li>
+     *   <li>Verify that the transformer is only called once</li>
+     * </ol>
+     * @param context Test context
+     */
+    @Test
+    public void testCacheTransformationContent(final TestContext context) {
+        final Async async = context.async();
+        final JsonObject blogData = createBlog("Blog cache", user);
+        final JsonObject postCache = createPost("post-cache");
+        createBlogOrFail(blogData, user, context)
+        .compose(blog -> createPostOrFail(blog.getString("_id"), postCache, user, context).map(post -> new BlogAndPost(blog, post)))
+        .compose(blogAndPost -> simulateOldContentData(blogAndPost.post).map(e -> blogAndPost))
+        .onSuccess(e -> contentTransformerClient.resetNbCalls())
+        .compose(blogAndPost -> getPostOrFailNTimes(blogAndPost.blog, blogAndPost.post, nbTimesGetSamePost, context))
+        .onSuccess(e -> context.assertEquals(1, contentTransformerClient.nbCalls, "The cache didn't work, we should have called the transformer only once"))
+        .onSuccess(e -> async.complete())
+        .onFailure(context::fail)
+        .onSuccess(e -> async.complete());
+    }
+
+    private Future<Void> simulateOldContentData(JsonObject post) {
+        final Promise<Void> promise = Promise.promise();
+        final QueryBuilder query = QueryBuilder.start("_id").is(post.getString("_id"));
+        MongoUpdateBuilder simulateOldUpdateQuery = new MongoUpdateBuilder();
+        simulateOldUpdateQuery.unset("jsonContent");
+        simulateOldUpdateQuery.unset("contentVersion");
+        mongoDb.update("posts", MongoQueryBuilder.build(query), simulateOldUpdateQuery.build(), message -> {
+            final JsonObject body = message.body();
+            if (isOk(body)) {
+                promise.complete();
+            } else {
+                promise.fail("Error while removing new editor content fields : " + body);
+            }
+        });
+        return promise.future();
+    }
+
+    private Future<Void> getPostOrFailNTimes(final JsonObject blog, JsonObject post, final int nbTimesToGet, final TestContext context) {
+        final Promise<Void> promise = Promise.promise();
+        if(nbTimesToGet <= 0) {
+            promise.fail("nbTimesToGet should be a positive number");
+        } else {
+            postService.get(blog.getString("_id"), post.getString("_id"), PostService.StateType.DRAFT, e -> {
+                if(e.isLeft()) {
+                    promise.fail("Fail to get the post at iteration " + ( nbTimesGetSamePost - nbTimesToGet + 1) + " : " + e.right().getValue());
+                } else {
+                    final JsonObject fetchedPost = e.right().getValue();
+                    context.assertTrue(fetchedPost.containsKey("contentVersion"), "Fetched post should contain a version field");
+                    context.assertEquals(0, fetchedPost.getInteger("contentVersion"), "Content version should remain 0");
+                    context.assertEquals("<p>clean html</p>"+ post.getString("content"), fetchedPost.getString("content"));
+                    context.assertTrue(fetchedPost.containsKey("jsonContent"), "Fetched post should have a jsonContent field");
+                    if(nbTimesToGet == 1) {
+                        promise.complete();
+                    } else {
+                        getPostOrFailNTimes(blog, post, nbTimesToGet - 1, context).onComplete(promise);
+                    }
+                }
+            });
+        }
+        return promise.future();
+    }
+    private Future<JsonObject> createPostOrFail(String blogId, JsonObject postData, UserInfos user, final TestContext context) {
+        final Promise<JsonObject> promise = Promise.promise();
+        postService.create(blogId, postData, user, e -> {
+            if (e.isLeft()) {
+                context.fail("An error occurred while creating the post : " + e.left().getValue());
+                promise.fail(e.left().getValue());
+            } else {
+                promise.complete(e.right().getValue());
+            }
+        });
+        return promise.future();
+    }
+
+    private Future<JsonObject> createBlogOrFail(final JsonObject blogData, UserInfos user, final TestContext context) {
+        final Promise<JsonObject> promise = Promise.promise();
+        blogService.create(blogData, PostServiceContentTransformerTest.user, false, eventBlogCreation -> {
+            if (eventBlogCreation.isLeft()) {
+                context.fail("An error occurred while creating the blog : " + eventBlogCreation.left().getValue());
+                promise.fail(eventBlogCreation.left().getValue());
+            } else {
+                promise.complete(eventBlogCreation.right().getValue());
+            }
+        });
+        return promise.future();
+    }
+
     static class DummyContentTransformerClient implements IContentTransformerClient {
+
+        /** Number of times a transformation has been asked.*/
+        private int nbCalls = 0;
 
         @Override
         public Future<ContentTransformerResponse> transform(ContentTransformerRequest contentTransformerRequest) {
+            nbCalls++;
             return Future.succeededFuture(new ContentTransformerResponse(1, null, new JsonObject().put("content", contentTransformerRequest.getHtmlContent()).getMap(), "plainTextContent", "<p>clean html</p>"+contentTransformerRequest.getHtmlContent(), null));
+        }
+
+        public void resetNbCalls() {
+            nbCalls = 0;
+        }
+
+        public int getNbCalls() {
+            return nbCalls;
         }
     }
 
 
     static JsonObject createPost(final String name) {
         return new JsonObject().put("title", name).put("content", "<div> description" + name + " </div>").put("state", "PUBLISHED");
+    }
+
+    static class BlogAndPost {
+        final JsonObject blog;
+
+        public BlogAndPost(JsonObject blog, JsonObject post) {
+            this.blog = blog;
+            this.post = post;
+        }
+
+        final JsonObject post;
     }
 }


### PR DESCRIPTION
# Description 

Sauvegarder en base de données le résultat de l'appel au transformateur de contenu pour les publications de blogs ayant été créés avant l'arrivée du nouvel éditeur et n'ayant pas encore été migrés.

# Ticket

[WB-2294](https://edifice-community.atlassian.net/browse/WB-2294)

[WB-2294]: https://edifice-community.atlassian.net/browse/WB-2294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ