### PR TITLE
feat: #WB-2335, route hash-based URLs

### DIFF
--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -27,14 +27,25 @@ const routes = (queryClient: QueryClient) => [
           };
         },
       },
-      // TODO postLoader
       // Post is the page containing a spécific post from a blog
       {
-        path: "/id/:blogId/post/:postId",
+        path: "id/:blogId/post/:postId",
         async lazy() {
-          const { PostView } = await import("~/routes/post");
+          const { Component, loader } = await import("~/routes/post");
           return {
-            Component: PostView,
+            loader: loader(queryClient),
+            Component,
+          };
+        },
+      },
+      // RETRO-COMPATIBLE routes below / or 404 ---------
+      {
+        path: "*",
+        async lazy() {
+          const { LoadNgRoutes: loader } = await import("./old-format");
+          return {
+            loader,
+            element: <div>404 - Not found</div>, //FIXME
           };
         },
       },

--- a/frontend/src/routes/old-format/index.tsx
+++ b/frontend/src/routes/old-format/index.tsx
@@ -3,7 +3,12 @@ import { useEffect } from "react";
 import { useOdeTheme } from "@edifice-ui/react";
 import { QueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
-import { LoaderFunctionArgs, useLoaderData } from "react-router-dom";
+import {
+  LoaderFunctionArgs,
+  matchPath,
+  redirect,
+  useLoaderData,
+} from "react-router-dom";
 
 import { Post } from "~/models/post";
 import { postQuery } from "~/services/queries";
@@ -51,4 +56,22 @@ export const Component = () => {
       }}
     />
   );
+};
+
+/** A loader that manages angularJs-styled routes. */
+export const LoadNgRoutes = () => {
+  if (!location.hash?.startsWith("#")) return null;
+
+  const ngLocation = location.hash.substring(1);
+  const blog = matchPath("/view/:blogId", ngLocation);
+  if (blog) {
+    return redirect(`id/${blog.params.blogId}`);
+  }
+
+  const post = matchPath("/detail/:blogId/:postId", ngLocation);
+  if (post) {
+    return redirect(`id/${post.params.blogId}/post/${post.params.postId}`);
+  }
+
+  throw "404";
 };

--- a/frontend/src/routes/post/index.tsx
+++ b/frontend/src/routes/post/index.tsx
@@ -1,3 +1,33 @@
-export const PostView = () => {
-  return <div></div>;
-};
+import { useRef, useState } from "react";
+
+import { Editor, EditorRef } from "@edifice-ui/editor";
+import { QueryClient } from "@tanstack/react-query";
+import { LoaderFunctionArgs, useLoaderData } from "react-router-dom";
+
+import { Post } from "~/models/post";
+import { postQuery } from "~/services/queries";
+
+
+/** Load a blog post content */
+export const loader =
+  (queryClient: QueryClient) =>
+  async ({ params }: LoaderFunctionArgs) => {
+    const { blogId, postId } = params;
+    if (blogId && postId) {
+      const query = postQuery(blogId, postId);
+      return (
+        queryClient.getQueryData(query.queryKey) ??
+        (await queryClient.fetchQuery(query))
+      );
+    }
+    return Promise.resolve(null);
+  };
+
+export function Component() {
+  const post = useLoaderData() as Post | null;
+  const editorRef = useRef<EditorRef>(null);
+  const [content /*, setContent*/] = useState(post?.content ?? "");
+  const [mode /*, setMode*/] = useState<"read" | "edit">("read");
+
+  return <Editor ref={editorRef} content={content} mode={mode}></Editor>;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -42,7 +42,7 @@ export default ({ mode }: { mode: string }) => {
     "^/(?=theme|locale|i18n|skin)": proxyObj,
     "^/(?=auth|appregistry|cas|userbook|directory|communication|conversation|portal|session|timeline|workspace|infra)":
       proxyObj,
-    "/blog": proxyObj,
+    "^/blog(?!#)/": proxyObj,
     "/explorer": proxyObj,
   };
 


### PR DESCRIPTION
* A new route path analyses the current location fragment (hash) to detect the following patterns : 
`#/view/:blogId` => redirects to the blog view,
`#/detail/:blogId/:postId` => redirects to post view
If a hash is found but not recognized, an error page will be displayed.

* The vite-server config file won't let `/blog#`-type URLs be proxified (for local dev)