### PR TITLE
feat: #WB-2381, add GET params to fetch posts content and comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 .idea
 .gradle
+node_modules
+.vscode
+build

--- a/backend/src/main/java/org/entcore/blog/controllers/BlogController.java
+++ b/backend/src/main/java/org/entcore/blog/controllers/BlogController.java
@@ -65,6 +65,8 @@ import org.entcore.common.utils.ResourceUtils;
 import org.entcore.common.utils.StringUtils;
 import org.vertx.java.core.http.RouteMatcher;
 
+import org.entcore.blog.to.PostProjection;
+
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -734,7 +736,7 @@ public class BlogController extends BaseController {
 			}
 			Future<JsonArray> futureList = Future.future();
 			//fetch posts
-			postService.list(blogId, user, null, 0, "", null, true, event -> {
+			postService.list(blogId, user, null, 0, "", null, new PostProjection(true, true, false), event -> {
 				if (event.isRight()) {
 					JsonArray posts = event.right().getValue();
 					futureList.complete(posts);

--- a/backend/src/main/java/org/entcore/blog/services/PostService.java
+++ b/backend/src/main/java/org/entcore/blog/services/PostService.java
@@ -25,6 +25,7 @@ package org.entcore.blog.services;
 import fr.wseduc.webutils.Either;
 import io.vertx.core.Future;
 import org.entcore.blog.to.PostFilter;
+import org.entcore.blog.to.PostProjection;
 import org.entcore.common.user.UserInfos;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
@@ -36,34 +37,41 @@ import java.util.Set;
 
 public interface PostService {
 
-	enum StateType { DRAFT, SUBMITTED, PUBLISHED };
+	enum StateType {
+		DRAFT, SUBMITTED, PUBLISHED
+	};
 
 	List<String> FIELDS = Arrays.asList("author", "title", "content",
 			"blog", "state", "comments", "created", "modified", "views");
 
 	List<String> UPDATABLE_FIELDS = Arrays.asList("title", "content", "modified");
 
-	void create(String blogId, JsonObject post, UserInfos author, boolean originalFormat, Handler<Either<String, JsonObject>> result);
+	void create(String blogId, JsonObject post, UserInfos author, boolean originalFormat,
+			Handler<Either<String, JsonObject>> result);
 
-	void update(String postId, JsonObject post, UserInfos user, boolean originalFormat, Handler<Either<String, JsonObject>> result);
+	void update(String postId, JsonObject post, UserInfos user, boolean originalFormat,
+			Handler<Either<String, JsonObject>> result);
 
 	void delete(UserInfos user, String blogId, String postId, Handler<Either<String, JsonObject>> result);
 
 	/**
 	 *
 	 * @param filter Filter that describes the desired post.
-	 * @return Fetched post iff the post with the specified id and state belongs to the blog with the specified id.
+	 * @return Fetched post iff the post with the specified id and state belongs to
+	 *         the blog with the specified id.
 	 */
 	Future<JsonObject> get(final PostFilter filter);
 
-	default void list(String blogId, UserInfos user, Integer page, int limit, String search, final Set<String> states, Handler<Either<String, JsonArray>> result){
-		list(blogId, user, page, limit, search, states, false, result);
+	default void list(String blogId, UserInfos user, Integer page, int limit, String search, final Set<String> states,
+			Handler<Either<String, JsonArray>> result) {
+		list(blogId, user, page, limit, search, states, new PostProjection(false, false, false), result);
 	}
-	void list(String blogId, UserInfos user, Integer page, int limit, String search, final Set<String> states, boolean withContent, Handler<Either<String, JsonArray>> result);
 
-	void listWithComments(String blogId, UserInfos user, Integer page, int limit, String search, final Set<String> states, boolean withContent, Handler<Either<String, JsonArray>> result);
+	void list(String blogId, UserInfos user, Integer page, int limit, String search,
+			final Set<String> states, final PostProjection projection, Handler<Either<String, JsonArray>> result);
 
-	void list(String blogId, StateType state, UserInfos user, Integer page, int limit, String search, Handler<Either<String, JsonArray>> result);
+	void list(String blogId, StateType state, UserInfos user, Integer page, int limit, String search,
+			Handler<Either<String, JsonArray>> result);
 
 	void listPublic(String blogId, Integer page, int limit, String search, Handler<Either<String, JsonArray>> result);
 
@@ -81,7 +89,7 @@ public interface PostService {
 			Handler<Either<String, JsonObject>> result);
 
 	void updateComment(String postId, final String commentId, final String comment, final UserInfos coauthor,
-				  final Handler<Either<String, JsonObject>> result);
+			final Handler<Either<String, JsonObject>> result);
 
 	void deleteComment(String blogId, String commentId, UserInfos author, Handler<Either<String, JsonObject>> result);
 

--- a/backend/src/main/java/org/entcore/blog/to/PostProjection.java
+++ b/backend/src/main/java/org/entcore/blog/to/PostProjection.java
@@ -1,0 +1,27 @@
+package org.entcore.blog.to;
+
+public class PostProjection {
+
+  private final boolean withContent;
+  private final boolean withComments;
+  private final boolean withNbComments;
+
+
+  public PostProjection(boolean withContent, boolean withComments, boolean withNbComments) {
+    this.withContent = withContent;
+    this.withComments = withComments;
+    this.withNbComments = withNbComments;
+  }
+
+  public boolean isWithContent() {
+    return withContent;
+  }
+
+  public boolean isWithComments() {
+    return withComments;
+  }
+
+  public boolean isWithNbComments() {
+    return withNbComments;
+  }
+}


### PR DESCRIPTION
# Description

Add the following GET parameters to the endpoint `/blog/list/all` in order to allow the caller to selectively request the content, the comments and/or their number.

- content
- comments
- nbComments

=> the method `list` and `listWithComments` have been merged and the resulting function only takes a `PostProjection` instance as a parameter to decide which fields to send back.

This PR also adds the GET param `pageSize` to specify the size of the page to fetch

# Ticket

WB-2381